### PR TITLE
Settings improvements

### DIFF
--- a/object-lifetime/CMakeLists.txt
+++ b/object-lifetime/CMakeLists.txt
@@ -30,9 +30,9 @@ if (OPENCL_LAYERS_BUILD_TESTING AND OFF) # Temporarily disable tests
     )
     set(TEST_ENVIRONMENT
             OPENCL_LAYERS=$<TARGET_FILE:CLObjectLifetimeLayer>
-            CL_OBJECT_LIFETIME_TRANSPARENT=1
-            CL_OBJECT_LIFETIME_LOG_SINK=file
-            CL_OBJECT_LIFETIME_LOG_FILENAME=CLObjectLifetimeLayerTest.log)
+            OPENCL_OBJECT_LIFETIME_TRANSPARENT=1
+            OPENCL_OBJECT_LIFETIME_LOG_SINK=file
+            OPENCL_OBJECT_LIFETIME_LOG_FILENAME=CLObjectLifetimeLayerTest.log)
     set_tests_properties (CLObjectLifetimeLayerTest
         PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}"
     )

--- a/object-lifetime/object_lifetime.cpp
+++ b/object-lifetime/object_lifetime.cpp
@@ -670,12 +670,13 @@ void init_output_stream() {
     break;
   case layer_settings::DebugLogType::File:
     log_stream.reset(new std::ofstream(settings.log_filename));
-    break;
-  }
+    if (log_stream->fail()) {
+      log_stream.reset(&std::cerr);
+      *log_stream << "object_lifetime failed to open specified output stream: "
+                  << settings.log_filename << ". Falling back to stderr." << '\n';
+    }
 
-  if(log_stream->fail()) {
-    std::cerr << "object_lifetime failed to open specified output stream: "
-              << settings.log_filename << ". Falling back to stderr." << '\n';
+    break;
   }
 } // namespace
 

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -10,5 +10,6 @@ add_executable(print_settings_location print_settings_location.cpp)
 target_link_libraries(print_settings_location PRIVATE LayersUtils LayersCommon)
 
 include(test_settings_location.cmake)
+include(test_settings.cmake)
 
 endif()

--- a/utils/print_setting_bool.cpp
+++ b/utils/print_setting_bool.cpp
@@ -1,0 +1,49 @@
+#include "utils.hpp"
+
+#include <iostream>
+#include <string>
+#include <cstdlib>
+
+int main(int argc, char* argv[]) {
+  auto parse_bool = [](const std::string& str, const char* param, bool& value) {
+    if (str == "true")
+    {
+      value = true;
+    }
+    else if (str == "false")
+    {
+      value = false;
+    }
+    else
+    {
+      std::cerr << "error: <" << param << "> must be 'true' or 'false'" << std::endl;
+      return false;
+    }
+    return true;
+  };
+
+  if (argc <= 4) {
+    std::cerr << "usage: " << argv[0] << " <prefix> <setting> <default> <expected>" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  const auto settings = ocl_layer_utils::load_settings();
+  const auto parser =
+    ocl_layer_utils::settings_parser(argv[1], settings);
+
+  bool value;
+  if (!parse_bool(argv[3], "default", value))
+  {
+    return EXIT_FAILURE;
+  }
+
+  parser.get_bool(argv[2], value);
+  std::cout << (value ? "true" : "false") << std::endl;
+
+  bool expected;
+  if (!parse_bool(argv[4], "expected", expected))
+  {
+    return EXIT_FAILURE;
+  }
+  return value == expected ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/utils/print_setting_enum.cpp
+++ b/utils/print_setting_enum.cpp
@@ -1,0 +1,27 @@
+#include "utils.hpp"
+
+#include <iostream>
+#include <string>
+#include <map>
+#include <cstdlib>
+
+int main(int argc, char* argv[]) {
+  if (argc <= 5) {
+    std::cerr << "usage: " << argv[0] << " <prefix> <setting> <default> <expected> <variants...>" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  const auto settings = ocl_layer_utils::load_settings();
+  const auto parser =
+    ocl_layer_utils::settings_parser(argv[1], settings);
+
+  std::map<std::string, std::string> options;
+  for (int i = 5; i < argc; ++i) {
+    options.insert({std::string(argv[i]), std::string(argv[i])});
+  }
+
+  std::string value = argv[3];
+  parser.get_enumeration(argv[2], options, value);
+
+  return value == argv[4] ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/utils/print_setting_filename.cpp
+++ b/utils/print_setting_filename.cpp
@@ -1,0 +1,22 @@
+#include "utils.hpp"
+
+#include <iostream>
+#include <string>
+#include <cstdlib>
+
+int main(int argc, char* argv[]) {
+  if (argc <= 4) {
+    std::cerr << "usage: " << argv[0] << " <prefix> <setting> <default> <expected>" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  const auto settings = ocl_layer_utils::load_settings();
+  const auto parser =
+    ocl_layer_utils::settings_parser(argv[1], settings);
+
+  std::string value = argv[3];
+  parser.get_filename(argv[2], value);
+  std::cout << value << std::endl;
+
+  return value == argv[4] ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/utils/test_settings.cmake
+++ b/utils/test_settings.cmake
@@ -1,0 +1,282 @@
+include(CMakeParseArguments)
+
+add_executable(print_setting_filename print_setting_filename.cpp)
+target_link_libraries(print_setting_filename PRIVATE LayersUtils LayersCommon)
+
+add_executable(print_setting_bool print_setting_bool.cpp)
+target_link_libraries(print_setting_bool PRIVATE LayersUtils LayersCommon)
+
+add_executable(print_setting_enum print_setting_enum.cpp)
+target_link_libraries(print_setting_enum PRIVATE LayersUtils LayersCommon)
+
+function(test_settings)
+  cmake_parse_arguments(PARSE_ARGV 0 ARG "" "NAME;SETTINGS;SETTING;SETTING_TYPE;DEFAULT;EXPECTED" "ENVIRONMENT;VARIANTS")
+
+  string(REPLACE "." ";" SETTING_ITEMS "${ARG_SETTING}")
+  list(GET SETTING_ITEMS 0 LAYER_NAME)
+  list(GET SETTING_ITEMS 1 SETTING_NAME)
+
+  set(SETTINGS_PATH "${CMAKE_CURRENT_BINARY_DIR}/test-${ARG_NAME}.txt")
+  file(WRITE "${SETTINGS_PATH}" "${ARG_SETTINGS}")
+
+  set(ENVIRONMENT "OPENCL_LAYERS_SETTINGS_PATH=${SETTINGS_PATH}")
+  list(APPEND ENVIRONMENT "${ARG_ENVIRONMENT}")
+
+  if(ARG_SETTING_TYPE STREQUAL "bool")
+    set(TEST_EXE $<TARGET_FILE:print_setting_bool>)
+  elseif(ARG_SETTING_TYPE STREQUAL "filename")
+    set(TEST_EXE $<TARGET_FILE:print_setting_filename>)
+  elseif(ARG_SETTING_TYPE STREQUAL "enum")
+    set(TEST_EXE $<TARGET_FILE:print_setting_enum>)
+  else()
+    message(FATAL_ERROR "invalid setting type ${SETTING_TYPE}")
+  endif()
+
+  add_test(
+    NAME "${ARG_NAME}"
+    COMMAND
+      "${TEST_EXE}" "${LAYER_NAME}" "${SETTING_NAME}" "${ARG_DEFAULT}" "${ARG_EXPECTED}" ${ARG_VARIANTS}
+  )
+  set_tests_properties(
+    "${ARG_NAME}"
+    PROPERTIES ENVIRONMENT "${ENVIRONMENT}"
+  )
+endfunction()
+
+# Test retrieving the default if no config option and no override is set.
+test_settings(
+  NAME Settings-Default-Filename
+  SETTING_TYPE filename
+  SETTINGS ""
+  SETTING test_layer.test_setting
+  DEFAULT default
+  EXPECTED default
+)
+
+test_settings(
+  NAME Settings-Default-Bool
+  SETTING_TYPE bool
+  SETTINGS ""
+  SETTING test_layer.test_setting
+  DEFAULT false
+  EXPECTED false
+)
+
+test_settings(
+  NAME Settings-Default-Enum
+  SETTING_TYPE enum
+  SETTINGS ""
+  SETTING test_layer.test_setting
+  DEFAULT default
+  EXPECTED default
+  VARIANTS default config override
+)
+
+# Test overriding the default if no config option is set.
+test_settings(
+  NAME Settings-Override-Default-Filename
+  SETTING_TYPE filename
+  SETTINGS ""
+  SETTING test_layer.test_setting
+  DEFAULT default
+  EXPECTED override
+  ENVIRONMENT OPENCL_TEST_LAYER_TEST_SETTING=override
+)
+
+test_settings(
+  NAME Settings-Override-Default-Bool
+  SETTING_TYPE bool
+  SETTINGS ""
+  SETTING test_layer.test_setting
+  DEFAULT false
+  EXPECTED true
+  ENVIRONMENT OPENCL_TEST_LAYER_TEST_SETTING=true
+)
+
+test_settings(
+  NAME Settings-Override-Default-Enum
+  SETTING_TYPE enum
+  SETTINGS ""
+  SETTING test_layer.test_setting
+  DEFAULT default
+  EXPECTED override
+  VARIANTS default config override
+  ENVIRONMENT OPENCL_TEST_LAYER_TEST_SETTING=override
+)
+
+# Test setting the value from the config.
+test_settings(
+  NAME Settings-Config-Filename
+  SETTING_TYPE filename
+  SETTINGS "test_layer.test_setting=test_setting_value"
+  SETTING test_layer.test_setting
+  DEFAULT default
+  EXPECTED test_setting_value
+)
+
+test_settings(
+  NAME Settings-Config-Bool
+  SETTING_TYPE bool
+  SETTINGS "test_layer.test_setting=true"
+  SETTING test_layer.test_setting
+  DEFAULT false
+  EXPECTED true
+)
+
+test_settings(
+  NAME Settings-Config-Enum
+  SETTING_TYPE enum
+  SETTINGS "test_layer.test_setting=config"
+  SETTING test_layer.test_setting
+  DEFAULT default
+  EXPECTED config
+  VARIANTS default config override
+)
+
+# Test overriding the value set from the config.
+test_settings(
+  NAME Settings-Override-Config
+  SETTING_TYPE enum
+  SETTINGS test_layer.test_setting=config
+  SETTING test_layer.test_setting
+  DEFAULT default
+  EXPECTED override
+  VARIANTS default config override
+  ENVIRONMENT OPENCL_TEST_LAYER_TEST_SETTING=override
+)
+
+# Test general settings file parsing.
+test_settings(
+  NAME Settings-Config-Comment
+  SETTING_TYPE filename
+  SETTINGS "#test_layer.test_setting=test_setting_value"
+  SETTING test_layer.test_setting
+  DEFAULT default
+  EXPECTED default
+)
+
+test_settings(
+  NAME Settings-Config-Whitespace
+  SETTING_TYPE filename
+  SETTINGS "\n\ntest_layer.test_setting=test_with_whitespace"
+  SETTING test_layer.test_setting
+  DEFAULT default
+  EXPECTED test_with_whitespace
+)
+
+test_settings(
+  NAME Settings-Config-Multi
+  SETTING_TYPE filename
+  SETTINGS "test_layer.first_setting=first_value\ntest_layer.second_setting=second_value"
+  SETTING test_layer.first_setting
+  DEFAULT default
+  EXPECTED first_value
+)
+
+test_settings(
+  NAME Settings-Config-Multi-2
+  SETTING_TYPE filename
+  SETTINGS "test_layer.first_setting=first_value\ntest_layer.second_setting=second_value"
+  SETTING test_layer.second_setting
+  DEFAULT default
+  EXPECTED second_value
+)
+
+test_settings(
+  NAME Settings-Override-Config-Multi-2
+  SETTING_TYPE filename
+  SETTINGS "test_layer.first_setting=first_value\ntest_layer.second_setting=second_value"
+  SETTING test_layer.second_setting
+  DEFAULT default
+  EXPECTED override
+  ENVIRONMENT OPENCL_TEST_LAYER_SECOND_SETTING=override
+)
+
+# Test bool values.
+test_settings(
+  NAME Settings-Bool-Yes
+  SETTING_TYPE bool
+  SETTINGS "test_layer.test_setting=yes"
+  SETTING test_layer.test_setting
+  DEFAULT false
+  EXPECTED true
+)
+
+test_settings(
+  NAME Settings-Bool-1
+  SETTING_TYPE bool
+  SETTINGS "test_layer.test_setting=1"
+  SETTING test_layer.test_setting
+  DEFAULT false
+  EXPECTED true
+)
+
+test_settings(
+  NAME Settings-Bool-0
+  SETTING_TYPE bool
+  SETTINGS "test_layer.test_setting=0"
+  SETTING test_layer.test_setting
+  DEFAULT true
+  EXPECTED false
+)
+
+# Test invalid values
+test_settings(
+  NAME Settings-Bool-Invalid-False
+  SETTING_TYPE bool
+  SETTINGS "test_layer.test_setting=invalid"
+  SETTING test_layer.test_setting
+  DEFAULT false
+  EXPECTED false
+)
+
+test_settings(
+  NAME Settings-Bool-Invalid-True
+  SETTING_TYPE bool
+  SETTINGS "test_layer.test_setting=invalid"
+  SETTING test_layer.test_setting
+  DEFAULT true
+  EXPECTED true
+)
+
+test_settings(
+  NAME Settings-Enum-Invalid
+  SETTING_TYPE enum
+  SETTINGS "test_layer.test_setting=invalid"
+  SETTING test_layer.test_setting
+  DEFAULT default
+  EXPECTED default
+  VARIANTS default config override
+)
+
+# Invalid value from environment fallback.
+test_settings(
+  NAME Settings-Bool-Invalid-Config
+  SETTING_TYPE bool
+  SETTINGS "test_layer.test_setting=invalid"
+  SETTING test_layer.test_setting
+  DEFAULT true
+  EXPECTED true
+)
+
+test_settings(
+  NAME Settings-Bool-Invalid-Override
+  SETTING_TYPE bool
+  SETTINGS "test_layer.test_setting=n"
+  SETTING test_layer.test_setting
+  DEFAULT true
+  EXPECTED false
+  ENVIRONMENT OPENCL_TEST_LAYER_TEST_SETTING=invalid
+)
+
+test_settings(
+  NAME Settings-Enum-Invalid-Override
+  SETTING_TYPE enum
+  SETTINGS "test_layer.test_setting=config"
+  SETTING test_layer.test_setting
+  DEFAULT default
+  EXPECTED config
+  VARIANTS default config override
+  ENVIRONMENT OPENCL_TEST_LAYER_TEST_SETTING=invalid
+)
+

--- a/utils/test_settings.cmake
+++ b/utils/test_settings.cmake
@@ -165,6 +165,24 @@ test_settings(
 )
 
 test_settings(
+  NAME Settings-Config-Whitespace-2
+  SETTING_TYPE bool
+  SETTINGS "test_layer.test_setting = false"
+  SETTING test_layer.test_setting
+  DEFAULT true
+  EXPECTED false
+)
+
+test_settings(
+  NAME Settings-Config-Trailing-Comment
+  SETTING_TYPE filename
+  SETTINGS "test_layer.test_setting = test_value # comment"
+  SETTING test_layer.test_setting
+  DEFAULT default
+  EXPECTED test_value
+)
+
+test_settings(
   NAME Settings-Config-Multi
   SETTING_TYPE filename
   SETTINGS "test_layer.first_setting=first_value\ntest_layer.second_setting=second_value"

--- a/utils/utils.cpp
+++ b/utils/utils.cpp
@@ -237,26 +237,15 @@ std::map<std::string, std::string> load_settings() {
 }
 
 void settings_parser::get_bool(const char *option_name, bool &out) const {
-  if (settings_->find(prefix_ + "." + option_name) != settings_->end()) {
-    detail::parse_bool(settings_->at(prefix_ + "." + option_name), out);
-  }
-  std::string option_value;
-  if (detail::get_environment(detail::to_upper("CL_" + prefix_ + "_" + option_name), option_value))
-    detail::parse_bool(
-      option_value,
-      out);
+  get_option(option_name, [&out](const std::string &value) {
+    detail::parse_bool(value, out);
+  });
 }
 
-void settings_parser::get_filename(const char *option_name,
-                                   std::string &out) const {
-  const auto full_option_name = prefix_ + "." + option_name;
-  if (settings_->find(full_option_name) != settings_->end() &&
-      settings_->at(full_option_name) != "") {
-    out = settings_->at(full_option_name);
-  }
-  std::string env_option;
-  if (detail::get_environment(detail::to_upper("CL_" + prefix_ + "_" + option_name), env_option))
-    out = std::move(env_option);
+void settings_parser::get_filename(const char *option_name, std::string &out) const {
+  get_option(option_name, [&out](const std::string &value) {
+    out = value;
+  });
 }
 
 } // namespace ocl_layer_utils


### PR DESCRIPTION
This pull request implements some more of #5:
- `CL_` style variables are renamed to `OPENCL_` to make them more unified.
- Implemented tests for settings, these test both getting options via environment variables/the config file as well as parsing the contents of the options file/environment variables.
- Cleaned up the code dealing with fetching the string representing a particular option.
- Fixed a problem where the object lifetime log would not properly fall back to stderr if a the log file could not be opened.

~~Note: This PR is based off of #6, the actual changes comprise only of the most recent few commits. Once #6 is merged I will rebase.~~